### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/pyrretsoftware/ray/security/code-scanning/1](https://github.com/pyrretsoftware/ray/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents to build and upload artifacts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
